### PR TITLE
Não mostrar menu de participar ou sair para grupos raizes

### DIFF
--- a/src/pages/Group/GroupTabs/GroupTabs.tsx
+++ b/src/pages/Group/GroupTabs/GroupTabs.tsx
@@ -59,10 +59,9 @@ export  function GroupTabs(props: GroupTabsProps){
         }
         
         
-        {   context?.group.canEnter?
+        {   context?.group.canEnter && !context.group.rootGroup?
                 joined && !context.group.rootGroup?
                 <GroupSubmenu leave={leave}/>
-                // <button className="group-tab-button group-tab-participacao" onClick={leave}>Sair</button> 
                 :
                 <button className="group-tab-button group-tab-participacao" onClick={join}>Participar deste grupo</button> 
             : <></>


### PR DESCRIPTION
## Related Issue
Closes #210 

## Proposed Changes

  - Verifica se grupo é raiz e não mostra botão de participar/sair