### PR TITLE
FIX #608 corrigindo bug do nome saindo fora da caixa de perfil

### DIFF
--- a/src/components/ProfileInfo/ProfileBio/ProfileBio.less
+++ b/src/components/ProfileInfo/ProfileBio/ProfileBio.less
@@ -37,6 +37,8 @@
         text-decoration: none;
         color: inherit;
 
+        word-break: break-word;
+
         &[href] {
             cursor: pointer;
             will-change: text-decoration;


### PR DESCRIPTION
OBS: eu vi o bug pela devtools e testei a correção por lá. Meu pc não consegue rodar o univesi.me, por isso para ver se o bug foi resolvido, é um tag só.


prints:
![Captura de tela 2024-08-19 104608](https://github.com/user-attachments/assets/c355be23-be8b-4c75-a3ec-08e9ed8601e1)
![Captura de tela 2024-08-19 104754](https://github.com/user-attachments/assets/411da49a-197b-4ac4-834f-c08ab5939cb6)
![Captura de tela 2024-08-19 104836](https://github.com/user-attachments/assets/ba96a1a3-9e22-4d8a-a53e-7c7c653bdc5e)


closes #608 


