### PR TITLE
FIX #627: Botão de configurações do grupo não aparece para administrador

### DIFF
--- a/src/pages/Group/GroupSubmenu/GroupSubmenu.tsx
+++ b/src/pages/Group/GroupSubmenu/GroupSubmenu.tsx
@@ -11,7 +11,7 @@ export function GroupSubmenu(){
     const context = useContext(GroupContext);
     const authContext = useContext(AuthContext);
 
-    const options = useMemo(makeGroupOptions, [context?.group.id]);
+    const options = useMemo(makeGroupOptions, [ context?.group.id, authContext.user ]);
 
     if (!context || !hasAvailableOption(options, context.group))
         return null;


### PR DESCRIPTION
## Related Issue
Closes #627